### PR TITLE
Additional Helm Configurations added

### DIFF
--- a/helm/leanix-k8s-connector/templates/clusterrole.yaml
+++ b/helm/leanix-k8s-connector/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac -}}
+{{- if and (.Values.rbac) (not .Values.clusterRoleAlreadyCreated) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/leanix-k8s-connector/templates/clusterrolebinding.yaml
+++ b/helm/leanix-k8s-connector/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac -}}
+{{- if and (.Values.rbac) (not .Values.clusterRoleAlreadyCreated) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/leanix-k8s-connector/templates/cronjob.yaml
+++ b/helm/leanix-k8s-connector/templates/cronjob.yaml
@@ -25,8 +25,8 @@ spec:
             securityContext:
               readOnlyRootFilesystem: true
               runAsNonRoot: true
-              runAsUser: 65534
-              runAsGroup: 65534
+              runAsUser: {{ .Values.securityContext.userId | default 65534 }}
+              runAsGroup: {{ .Values.securityContext.groupId | default 65534 }}
               allowPrivilegeEscalation: false
             image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
             env:

--- a/helm/leanix-k8s-connector/values.yaml
+++ b/helm/leanix-k8s-connector/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 rbac: true
+clusterRoleAlreadyCreated: false
 
 integrationApi:
   enabled: false

--- a/helm/leanix-k8s-connector/values.yaml
+++ b/helm/leanix-k8s-connector/values.yaml
@@ -19,6 +19,10 @@ image:
   tag: 2.0.0-beta7
   pullPolicy: Always
 
+securityContext:
+  userId: 65534
+  groupId: 65534
+
 args:
   clustername: kubernetes
   connectorID: ""


### PR DESCRIPTION
Due to our internal Cluster Policies some changes on Helm Chart are required. This PR contains those requirements.

On our Cluster, the ClusterRoles and ClusterRoleBindings are being created by the Cluster Administrator. Due to this, the Helm-Chart does not have to create the CR and CRB.

Another thing that has to be configurable, is the UserId/GroupId for the SecurityContext. We don't allow all UserIds/GroupIds.