### PR TITLE
Adds a custom Env Field to Helm for a more flexible configuration

### DIFF
--- a/helm/leanix-k8s-connector/templates/cronjob.yaml
+++ b/helm/leanix-k8s-connector/templates/cronjob.yaml
@@ -76,6 +76,10 @@ spec:
                   name: "{{ .Values.integrationApi.secretName }}"
                   key: token
             {{- end }}
+            {{- range $key, $val := .Values.args.additionalEnv }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
             resources:
               requests:
                 cpu: {{ .Values.resources.requests.cpu }}

--- a/helm/leanix-k8s-connector/values.yaml
+++ b/helm/leanix-k8s-connector/values.yaml
@@ -39,10 +39,7 @@ args:
     container: ""
   blacklistNamespaces:
   - "kube-system"
-  additionalEnv:
-    FOO: "BAR"
-    HTTP_PROXY: "CHANGEME"
-    HTTPS_PROXY: "CHANGEME"
+  additionalEnv: {}
 
 nameOverride: ""
 fullnameOverride: ""

--- a/helm/leanix-k8s-connector/values.yaml
+++ b/helm/leanix-k8s-connector/values.yaml
@@ -39,6 +39,10 @@ args:
     container: ""
   blacklistNamespaces:
   - "kube-system"
+  additionalEnv:
+    FOO: "BAR"
+    HTTP_PROXY: "CHANGEME"
+    HTTPS_PROXY: "CHANGEME"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
In order to support custom env Fields such as Proxy Params and other, non image related configurations, I added the ability to the helm chart