### PR TITLE
CID-274 update os to k8sProperties

### DIFF
--- a/integration-api-default-config.json
+++ b/integration-api-default-config.json
@@ -125,7 +125,7 @@
 					},
 					{
 						"key": {
-							"expr": "os"
+							"expr": "k8sProperties"
 						},
 						"values": [
 							{


### PR DESCRIPTION
Fixing issue - {"message":"Field 'os' does not exist, or cannot be modified directly","category":"dataModel"}. Not new because of VSM. it was from MI as well