### PR TITLE
[HEL-1276]: Details on the default config for integration API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Create a new data source with k8s connector template(mentioned above) and add re
 | resolveStrategy | label/namespace |  empty  |    ✅     |
 |  resolveLabel   |   plain text    |  empty  |    ❌     |
 
+#### Integration API Default Configuration
+Default configurations are a list of Integration API configurations that are available on all workspaces automatically. 
+Availability and visibility can be still controlled using feature flags. The default configurations show all 
+processor configuration for a given workspace. 
+    In the context of `leanix-k8s-connector` the configuration file `integration-api-default-config`
+has feature flags `integration.integrationapi` and `integration.vsm.k8s` which needs to be enabled. 
+The configuration has list of `Processor Type` which enables updating the data from K8S Infrastructure. 
+It is important to know  iff certain changes on this file are needed and if you have no idea. Please contact #team-helios on Slack. 
+Additionally in the References Section you can find the Confulence link to details of Default Configurations.
 
 #### **Starting Connector in k8s**
 
@@ -624,3 +633,8 @@ e.g `--set args.storageBackend=file`
 |  2020-01-14  |    2.0.0-beta1    |        1.0.0        |    2.0.0-beta1     | 2.0.0-beta1-d5555d2 |
 |  2019-09-26  |       1.1.0       |        1.0.0        |       1.0.0        |       23d019b       |
 |  2019-08-28  |       1.0.0       |        1.0.0        |       1.0.0        |       b0bc069       |
+
+## References for detailed understanding
+[Integration API](https://leanix.atlassian.net/wiki/spaces/~956226893/pages/4296016089/Integration+API)  
+[Integration Hub](https://leanix.atlassian.net/wiki/spaces/FLOW/pages/7464358115/Integration+Hub+-+Getting+started+creating+a+Connector)  
+[Default Config iAPI](https://leanix.atlassian.net/wiki/spaces/EN/pages/1341784193/Default+Configuration+Management+in+Integration+API)  

--- a/README.md
+++ b/README.md
@@ -125,12 +125,16 @@ Create a new data source with k8s connector template(mentioned above) and add re
 #### Integration API Default Configuration
 Default configurations are a list of Integration API configurations that are available on all workspaces automatically. 
 Availability and visibility can be still controlled using feature flags. The default configurations show all 
-processor configuration for a given workspace. 
-    In the context of `leanix-k8s-connector` the configuration file `integration-api-default-config`
+processor configuration for a given workspace.
+ 
+In the context of `leanix-k8s-connector` the configuration file `integration-api-default-config`
 has feature flags `integration.integrationapi` and `integration.vsm.k8s` which needs to be enabled. 
-The configuration has list of `Processor Type` which enables updating the data from K8S Infrastructure. 
-It is important to know  iff certain changes on this file are needed and if you have no idea. Please contact #team-helios on Slack. 
-Additionally in the References Section you can find the Confulence link to details of Default Configurations.
+
+[Sample Default configuration Explained](https://leanix.atlassian.net/wiki/spaces/EN/pages/1341784193/Default+Configuration+Management+in+Integration+API#Create-single-default-configuration)
+
+> It is important to know  iff certain changes on this file are needed and if you have no idea. Please contact #team-helios on Slack. 
+
+_Additionally in the [References](#references-for-detailed-understanding) Section you can find the Confulence link to details of Default Configurations._
 
 #### **Starting Connector in k8s**
 


### PR DESCRIPTION
1. The Scope of this Doc is the background of the Default config for Integration API without going in detail with individual configuration Type.
2. Details are referenced from already existing documentation(DRY)

Sample: 
![Screenshot 2021-11-24 at 10 47 46](https://user-images.githubusercontent.com/93667110/143214952-0197d671-c58f-4658-baf6-dda376f71e21.png)

~~Note: Point 1 is open for discussion. If we need details on individual configuration. I can try to add it.~~