### PR TITLE
[HEL-1136]: added new extension groups vsm-kubernetes-import-all, vsm-kubernetes-import-default

### DIFF
--- a/ihub-resources/connector-definition.json
+++ b/ihub-resources/connector-definition.json
@@ -7,13 +7,7 @@
 	  "resolveLabel": ""
 	},
 	"secretsConfiguration": {},
-	"bindingKey": {
-		"connectorType": "leanix-vsm-connector",
-		"connectorId": "leanic-k8s-connector",
-		"connectorVersion": "1.0.0",
-		"processingDirection": "inbound",
-		"processingMode": "full"
-	},
+	"executionGroup": "vsm-kubernetes-import-all",
 	"featureFlags": [
 	    {
       "featureFlags": [

--- a/integration-api-default-config.json
+++ b/integration-api-default-config.json
@@ -2543,7 +2543,9 @@
 		"processingThreads": 1,
 		"logLdifUrl": true,
 		"executionGroups": [
-			"vsmK8sInbound"
+			"vsmK8sInbound",
+			"vsm-kubernetes-import-all",
+			"vsm-kubernetes-import-default"
 		]
 	},
 	"availableIf": [


### PR DESCRIPTION
~~The scope of this ticket is to add new extension groups to the default config.~~
This PR takes care of HEL-1311 and HEL-1312.
## For Testing
1. Created a custom Processor Config(faked the k8s default config) and added execution group `vsm-kubernetes-import-all`
2. Also added the EG in the iHub instead of the `bindingKey`.
3.  Ran the cron job to see the custom config completed
![Screenshot 2021-11-29 at 17 17 19](https://user-images.githubusercontent.com/93667110/143903798-c90507f4-0f45-41c4-962a-74e9436c0005.png)
 
