### PR TITLE
[HEL-1750]: Adapt new URL for iHub with connector version

### DIFF
--- a/pkg/leanix/integration_hub.go
+++ b/pkg/leanix/integration_hub.go
@@ -12,6 +12,10 @@ import (
 	"github.com/op/go-logging"
 )
 
+const (
+	CONNECTOR_VERSION string = "6.4.1"
+)
+
 type SelfStartResponse struct {
 	RunId                  string                 `json:"runId"`
 	BindingKey             BindingKey             `json:"bindingKey"`
@@ -46,8 +50,10 @@ var log = logging.MustGetLogger("leanix-k8s-connector")
 
 // SelfStartRun initiates the Integration Hub run and response with id
 func SelfStartRun(fqdn string, accessToken string, datasource string) (*SelfStartResponse, error) {
-	datasourceRunUrl := "https://" + fqdn + "/services/integration-hub/v1/datasourceRuns/name/" + datasource + "/selfStart"
-	req, err := http.NewRequest("GET", datasourceRunUrl, nil)
+	datasourceRunUrl := fmt.Sprintf("https://%s/services/integration-hub/v1/datasources/%s/selfStart", fqdn, datasource)
+	req, err := http.NewRequest("POST", datasourceRunUrl, nil)
+	req.Header.Set("connector-version", CONNECTOR_VERSION)
+	req.Header.Set("connector-name", "k8s-connector")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	if err != nil {


### PR DESCRIPTION
1. Adapt  new URL from iHub supporting connector version.
2. Azure WorkBook [here](https://portal.azure.com/#@leanix.net/resource/subscriptions/95e3fca8-46f8-403e-85e9-6f97a3857c0e/resourceGroups/leanix-logging/providers/microsoft.insights/workbooks/fe23c41b-2865-47e3-abef-02d42311f065/workbook)
3. OpenAPI reference iHub --> https://app.leanix.net/openapi-explorer/#/datasources/connectorSelfStartedById
