### PR TITLE
HEL-2419 - [k8s] cronjob.yaml is using old apiVersion

### DIFF
--- a/helm/leanix-k8s-connector/templates/cronjob.yaml
+++ b/helm/leanix-k8s-connector/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "leanix-k8s-connector.fullname" . }}


### PR DESCRIPTION
fix cronjob yaml to use version v1 instead of v1beta