### PR TITLE
Bugfix/hel 2419

### DIFF
--- a/pkg/iris/mapping.go
+++ b/pkg/iris/mapping.go
@@ -1,20 +1,21 @@
 package iris
 
 import (
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/leanix/leanix-k8s-connector/pkg/iris/models"
 	"github.com/leanix/leanix-k8s-connector/pkg/kubernetes"
 	"github.com/leanix/leanix-k8s-connector/pkg/set"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"reflect"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type Mapper interface {
 	MapCluster(clusterName string, nodes *v1.NodeList) (ClusterDTO, error)
-	MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.Deployment, error)
+	MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.DeploymentEcst, error)
 }
 
 type mapper struct {
@@ -74,8 +75,8 @@ func (m *mapper) MapCluster(clusterName string, nodes *v1.NodeList) (ClusterDTO,
 	}, nil
 }
 
-func (m *mapper) MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.Deployment, error) {
-	var allDeployments []models.Deployment
+func (m *mapper) MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.DeploymentEcst, error) {
+	var allDeployments []models.DeploymentEcst
 
 	for _, deployment := range deployments.Items {
 		deploymentService := ""
@@ -87,12 +88,12 @@ func (m *mapper) MapDeployments(deployments *appsv1.DeploymentList, services *v1
 	return allDeployments, nil
 }
 
-func (m *mapper) CreateDeployment(deploymentService string, deployment appsv1.Deployment) models.Deployment {
+func (m *mapper) CreateDeployment(deploymentService string, deployment appsv1.Deployment) models.DeploymentEcst {
 	var service = ""
 	if deploymentService != "" {
 		service = deploymentService
 	}
-	mappedDeployment := models.Deployment{
+	mappedDeployment := models.DeploymentEcst{
 		ServiceName:    service,
 		Image:          deployment.Spec.Template.Spec.Containers[0].Image,
 		DeploymentName: deployment.Name,

--- a/pkg/iris/mapping.go
+++ b/pkg/iris/mapping.go
@@ -15,7 +15,8 @@ import (
 
 type Mapper interface {
 	MapCluster(clusterName string, nodes *v1.NodeList) (ClusterDTO, error)
-	MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.DeploymentEcst, error)
+	MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.Deployment, error)
+	MapDeploymentsEcst(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.DeploymentEcst, error)
 }
 
 type mapper struct {
@@ -75,8 +76,8 @@ func (m *mapper) MapCluster(clusterName string, nodes *v1.NodeList) (ClusterDTO,
 	}, nil
 }
 
-func (m *mapper) MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.DeploymentEcst, error) {
-	var allDeployments []models.DeploymentEcst
+func (m *mapper) MapDeployments(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.Deployment, error) {
+	var allDeployments []models.Deployment
 
 	for _, deployment := range deployments.Items {
 		deploymentService := ""
@@ -88,7 +89,38 @@ func (m *mapper) MapDeployments(deployments *appsv1.DeploymentList, services *v1
 	return allDeployments, nil
 }
 
-func (m *mapper) CreateDeployment(deploymentService string, deployment appsv1.Deployment) models.DeploymentEcst {
+func (m *mapper) MapDeploymentsEcst(deployments *appsv1.DeploymentList, services *v1.ServiceList) ([]models.DeploymentEcst, error) {
+	var allDeployments []models.DeploymentEcst
+
+	for _, deployment := range deployments.Items {
+		deploymentService := ""
+		// Check if any service has the exact same selector labels and use this as the service related to the deployment
+		deploymentService = ResolveK8sServiceForK8sDeployment(services, deployment)
+		allDeployments = append(allDeployments, m.CreateDeploymentEcst(deploymentService, deployment))
+	}
+
+	return allDeployments, nil
+}
+
+func (m *mapper) CreateDeployment(deploymentService string, deployment appsv1.Deployment) models.Deployment {
+
+	mappedDeployment := models.Deployment{
+		Service:        &models.Service{Name: deploymentService},
+		Image:          deployment.Spec.Template.Spec.Containers[0].Image,
+		DeploymentName: deployment.Name,
+		Labels:         deployment.ObjectMeta.Labels,
+		Timestamp:      deployment.CreationTimestamp.UTC().Format(time.RFC3339),
+		Properties: models.DeploymentProperties{
+			UpdateStrategy: string(deployment.Spec.Strategy.Type),
+			Replicas:       strconv.FormatInt(int64(deployment.Status.Replicas), 10),
+			K8sLimits:      CreateK8sResources(deployment.Spec.Template.Spec.Containers[0].Resources.Limits),
+			K8sRequests:    CreateK8sResources(deployment.Spec.Template.Spec.Containers[0].Resources.Requests),
+		},
+	}
+	return mappedDeployment
+}
+
+func (m *mapper) CreateDeploymentEcst(deploymentService string, deployment appsv1.Deployment) models.DeploymentEcst {
 	var service = ""
 	if deploymentService != "" {
 		service = deploymentService

--- a/pkg/iris/mapping_test.go
+++ b/pkg/iris/mapping_test.go
@@ -1,14 +1,15 @@
 package iris
 
 import (
+	"testing"
+	"time"
+
 	"github.com/leanix/leanix-k8s-connector/pkg/kubernetes"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 )
 
 func TestMapDeployments(t *testing.T) {
@@ -115,17 +116,29 @@ func TestMapDeployments(t *testing.T) {
 	}
 	mapper := NewMapper(&kubernetes.API{}, "cluster-test", "workspace-test", make([]string, 0), "test-runid")
 	result, err := mapper.MapDeployments(&dummyDeployments, &dummyServices)
+	resultEcst, err := mapper.MapDeploymentsEcst(&dummyDeployments, &dummyServices)
+
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
-
 	assert.Equal(t, "test-deployment-2", result[0].DeploymentName)
-	assert.Equal(t, "test-service-2", result[0].ServiceName)
-	assert.Equal(t, "100", result[0].DeploymentProperties.K8sRequests.Cpu)
-	assert.Equal(t, "50", result[0].DeploymentProperties.K8sRequests.Memory)
-	assert.Equal(t, "", result[0].DeploymentProperties.K8sLimits.Cpu)
-	assert.Equal(t, "", result[0].DeploymentProperties.K8sLimits.Memory)
-	assert.Equal(t, "1", result[0].DeploymentProperties.Replicas)
+	assert.Equal(t, "test-service-2", result[0].Service.Name)
+	assert.Equal(t, "100", result[0].Properties.K8sRequests.Cpu)
+	assert.Equal(t, "50", result[0].Properties.K8sRequests.Memory)
+	assert.Equal(t, "", result[0].Properties.K8sLimits.Cpu)
+	assert.Equal(t, "", result[0].Properties.K8sLimits.Memory)
+	assert.Equal(t, "1", result[0].Properties.Replicas)
 	assert.Equal(t, "testImage", result[0].Image)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resultEcst)
+	assert.Equal(t, "test-deployment-2", resultEcst[0].DeploymentName)
+	assert.Equal(t, "test-service-2", resultEcst[0].ServiceName)
+	assert.Equal(t, "100", resultEcst[0].DeploymentProperties.K8sRequests.Cpu)
+	assert.Equal(t, "50", resultEcst[0].DeploymentProperties.K8sRequests.Memory)
+	assert.Equal(t, "", resultEcst[0].DeploymentProperties.K8sLimits.Cpu)
+	assert.Equal(t, "", resultEcst[0].DeploymentProperties.K8sLimits.Memory)
+	assert.Equal(t, "1", resultEcst[0].DeploymentProperties.Replicas)
+	assert.Equal(t, "testImage", resultEcst[0].Image)
 }
 
 func TestMapDeployments_NoService(t *testing.T) {
@@ -206,17 +219,30 @@ func TestMapDeployments_NoService(t *testing.T) {
 	}
 	mapper := NewMapper(&kubernetes.API{}, "cluster-test", "workspace-test", make([]string, 0), "test-runid")
 	result, err := mapper.MapDeployments(&dummyDeployments, &dummyServices)
+	resultEcst, err := mapper.MapDeploymentsEcst(&dummyDeployments, &dummyServices)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
 
 	assert.Equal(t, "test-deployment-2", result[0].DeploymentName)
-	assert.Empty(t, result[0].ServiceName)
-	assert.Equal(t, "100", result[0].DeploymentProperties.K8sRequests.Cpu)
-	assert.Equal(t, "50", result[0].DeploymentProperties.K8sRequests.Memory)
-	assert.Equal(t, "", result[0].DeploymentProperties.K8sLimits.Cpu)
-	assert.Equal(t, "", result[0].DeploymentProperties.K8sLimits.Memory)
-	assert.Equal(t, "1", result[0].DeploymentProperties.Replicas)
+	assert.Empty(t, result[0].Service.Name)
+	assert.Equal(t, "100", result[0].Properties.K8sRequests.Cpu)
+	assert.Equal(t, "50", result[0].Properties.K8sRequests.Memory)
+	assert.Equal(t, "", result[0].Properties.K8sLimits.Cpu)
+	assert.Equal(t, "", result[0].Properties.K8sLimits.Memory)
+	assert.Equal(t, "1", result[0].Properties.Replicas)
 	assert.Equal(t, "testImage", result[0].Image)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resultEcst)
+
+	assert.Equal(t, "test-deployment-2", resultEcst[0].DeploymentName)
+	assert.Empty(t, resultEcst[0].ServiceName)
+	assert.Equal(t, "100", resultEcst[0].DeploymentProperties.K8sRequests.Cpu)
+	assert.Equal(t, "50", resultEcst[0].DeploymentProperties.K8sRequests.Memory)
+	assert.Equal(t, "", resultEcst[0].DeploymentProperties.K8sLimits.Cpu)
+	assert.Equal(t, "", resultEcst[0].DeploymentProperties.K8sLimits.Memory)
+	assert.Equal(t, "1", resultEcst[0].DeploymentProperties.Replicas)
+	assert.Equal(t, "testImage", resultEcst[0].Image)
 }
 
 func TestGetCluster(t *testing.T) {

--- a/pkg/iris/models/clusterEcst.go
+++ b/pkg/iris/models/clusterEcst.go
@@ -1,12 +1,12 @@
 package models
 
 type ClusterEcst struct {
-	Namespace   string       `json:"namespaceName"`
-	Deployments []Deployment `json:"deployments"`
-	Name        string       `json:"clusterName"`
-	Os          string       `json:"os"`
-	K8sVersion  string       `json:"k8sVersion"`
-	NoOfNodes   string       `json:"noOfNodes"`
+	Namespace   string           `json:"namespaceName"`
+	Deployments []DeploymentEcst `json:"deployments"`
+	Name        string           `json:"clusterName"`
+	Os          string           `json:"os"`
+	K8sVersion  string           `json:"k8sVersion"`
+	NoOfNodes   string           `json:"noOfNodes"`
 }
 
 //Interface functions can go here

--- a/pkg/iris/models/workloads.go
+++ b/pkg/iris/models/workloads.go
@@ -3,6 +3,19 @@ package models
 // workloads
 
 type Deployment struct {
+	Service        *Service             `json:"service"`
+	Image          string               `json:"image"`
+	DeploymentName string               `json:"deploymentName"`
+	Labels         interface{}          `json:"labels"`
+	Timestamp      string               `json:"time"`
+	Properties     DeploymentProperties `json:"deploymentProperties"`
+}
+
+type Service struct {
+	Name string `json:"name"`
+}
+
+type DeploymentEcst struct {
 	ServiceName          string               `json:"serviceName"`
 	Image                string               `json:"image"`
 	DeploymentName       string               `json:"deploymentName"`

--- a/pkg/iris/models/workloads.go
+++ b/pkg/iris/models/workloads.go
@@ -8,7 +8,7 @@ type Deployment struct {
 	DeploymentName string               `json:"deploymentName"`
 	Labels         interface{}          `json:"labels"`
 	Timestamp      string               `json:"time"`
-	Properties     DeploymentProperties `json:"deploymentProperties"`
+	Properties     DeploymentProperties `json:"properties"`
 }
 
 type Service struct {


### PR DESCRIPTION
Made sure to have "old" discovery item structure (not ecst!) in line with this: https://leanix.atlassian.net/wiki/spaces/VSM/pages/7737704637/Kubernetes+Namespace

Should fix blank k8s page issue

Chose to keep it simple stupid: I just duplicated all the deployment mapping and creation methods. A bit less pretty code now, but once we get rid of the "old" discovery items we can just remove all these methods and we are good to go, no need for fancy refactoring.