### PR TITLE
Updated name to be displayed as{workloadType/workloadName}

### DIFF
--- a/pkg/iris/workloads/models/eventsEcst.go
+++ b/pkg/iris/workloads/models/eventsEcst.go
@@ -128,7 +128,7 @@ func CreateEcstDiscoveryEvent(eventType string, changeAction string, data Data, 
 
 	body := models.DiscoveryBody{
 		State: models.State{
-			Name:           data.Workload.ClusterName,
+			Name:           fmt.Sprintf("%s/%s", data.Workload.WorkloadType, data.Workload.WorkloadName),
 			SourceType:     "kubernetes",
 			SourceInstance: fmt.Sprintf("cluster/%s", data.Workload.ClusterName),
 			Time:           time,

--- a/pkg/iris/workloads/services/events/eventProducer_test.go
+++ b/pkg/iris/workloads/services/events/eventProducer_test.go
@@ -75,7 +75,7 @@ func Test_eventProducer_filter_created(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, updated)
 	assert.Len(t, created, 1)
-	assert.Equal(t, "testCluster1", created[0].Body.State.Name)
+	assert.Equal(t, "deployment/testWorkload1", created[0].Body.State.Name)
 }
 
 func Test_eventProducer_filter_updated_no_change(t *testing.T) {
@@ -394,7 +394,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 	assert.Equal(t, hex.EncodeToString(id1[:]), created[0].HeaderProperties.Id)
 	assert.Equal(t, models.EventTypeChange, created[0].HeaderProperties.Type)
 	assert.Equal(t, models.EventActionCreated, created[0].HeaderProperties.Action)
-	assert.Equal(t, "testCluster1", created[0].Body.State.Name)
+	assert.Equal(t, "deployment/testWorkload1", created[0].Body.State.Name)
 	// UPDATED
 	assert.Equal(t, models.EventTypeChange, updated[0].HeaderProperties.Type)
 	assert.Equal(t, models.EventActionUpdated, updated[0].HeaderProperties.Action)


### PR DESCRIPTION
Right now it is just the clusterName for EVERY event.
Now it will be easier for customers to distinguish what is actually inside of that event. The name now looks like:
- deployment/testWorkload1
- daemonSet/instana-agent-k8s-eu-prod-nodepool-eventcollector
- cronjob/technolot-rover