### PR TITLE
Bugfix/missing namespace cronjob

### DIFF
--- a/pkg/iris/workloads/models/eventsEcst.go
+++ b/pkg/iris/workloads/models/eventsEcst.go
@@ -4,8 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/leanix/leanix-k8s-connector/pkg/iris/common/models"
 	time2 "time"
+
+	"github.com/leanix/leanix-k8s-connector/pkg/iris/common/models"
 )
 
 // ECST Discovery Items
@@ -147,7 +148,7 @@ func CreateEcstDiscoveryEvent(eventType string, changeAction string, data Data, 
 func GenerateId(workspaceId string, configId string, data Data) string {
 	scope := fmt.Sprintf(models.EventScopeFormat, workspaceId, configId)
 	// workspace/{workspaceId}/configuration/{configurationId}/discoveryItem/service/kubernetes/workload/{clusterName}/{workloadType}/{workloadName}
-	idString := fmt.Sprintf("%s/%s/%s/%s/%s", scope, models.EventClassWorkload, data.Cluster.Name, data.Workload.WorkloadType, data.Workload.Name)
+	idString := fmt.Sprintf("%s/%s/%s/%s/%s/%s", scope, models.EventClassWorkload, data.Cluster.Name, data.Workload.WorkloadType, data.Workload.Name, data.NamespaceName)
 	sum := sha256.Sum256([]byte(idString))
 	id := hex.EncodeToString(sum[:])
 	return id

--- a/pkg/iris/workloads/services/events/eventProducer_test.go
+++ b/pkg/iris/workloads/services/events/eventProducer_test.go
@@ -4,12 +4,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"testing"
+
 	"github.com/leanix/leanix-k8s-connector/pkg/iris/common/models"
 	common "github.com/leanix/leanix-k8s-connector/pkg/iris/common/services"
 	workload "github.com/leanix/leanix-k8s-connector/pkg/iris/workloads/models"
 	"github.com/leanix/leanix-k8s-connector/pkg/mocks"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_eventProducer_filter_created(t *testing.T) {
@@ -257,11 +258,11 @@ func Test_eventProducer_filter_updated_changed(t *testing.T) {
 
 func Test_eventProducer_createECSTEvents(t *testing.T) {
 	mockApi := mocks.NewIrisApi(t)
-	id1 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster1", "deployment", "testWorkload1")))
+	id1 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster1", "deployment", "testWorkload1", "testNamespace")))
 	//workspace/testWorkspaceId/configuration/testConfigId/discoveryItem/service/kubernetes/workload/testCluster1/deployment/testWorkload2
-	id2 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster1", "deployment", "testWorkload2")))
-	id3 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster2", "deployment", "testWorkload1")))
-	id4 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster2", "deployment", "testWorkload2")))
+	id2 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster1", "deployment", "testWorkload2", "testNamespace")))
+	id3 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster2", "deployment", "testWorkload1", "testNamespace")))
+	id4 := sha256.Sum256([]byte(fmt.Sprintf("%s/%s/%s/%s/%s/%s", "workspace/testWorkspaceId/configuration/testConfigId", models.EventClassWorkload, "testCluster2", "deployment", "testWorkload2", "testNamespace")))
 	newData := []workload.Data{
 		{
 			Workload: workload.Workload{
@@ -282,7 +283,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 				},
 			},
 			ServiceName:   "serviceName1",
-			NamespaceName: "namespaceName1",
+			NamespaceName: "testNamespace",
 			Cluster: workload.Cluster{
 				Name:    "testCluster1",
 				OsImage: "linux",
@@ -312,7 +313,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 				OsImage: "linux",
 			},
 			ServiceName:   "serviceName2",
-			NamespaceName: "namespaceName2",
+			NamespaceName: "testNamespace",
 			Timestamp:     "",
 		},
 		{
@@ -338,7 +339,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 				OsImage: "linux",
 			},
 			ServiceName:   "serviceName3",
-			NamespaceName: "namespaceName3",
+			NamespaceName: "testNamespace",
 			Timestamp:     "",
 		},
 	}
@@ -377,7 +378,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 							OsImage: "linux",
 						},
 						ServiceName:   "serviceName1",
-						NamespaceName: "namespaceName1",
+						NamespaceName: "testNamespace",
 						Timestamp:     "",
 					},
 				},
@@ -417,7 +418,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 							OsImage: "linux",
 						},
 						ServiceName:   "serviceName2",
-						NamespaceName: "namespaceName2",
+						NamespaceName: "testNamespace",
 						Timestamp:     "",
 					},
 				},
@@ -457,7 +458,7 @@ func Test_eventProducer_createECSTEvents(t *testing.T) {
 							OsImage: "linux",
 						},
 						ServiceName:   "serviceName3",
-						NamespaceName: "namespaceName3",
+						NamespaceName: "testNamespace",
 						Timestamp:     "",
 					},
 				},

--- a/pkg/iris/workloads/services/mapper/mapping_test.go
+++ b/pkg/iris/workloads/services/mapper/mapping_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/leanix/leanix-k8s-connector/pkg/iris/workloads/models"
 	"github.com/leanix/leanix-k8s-connector/pkg/kubernetes"
-	"github.com/leanix/leanix-k8s-connector/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -19,7 +18,6 @@ import (
 )
 
 func Test_MapWorkloads_success(t *testing.T) {
-	logger.Init()
 	dummyServices := []runtime.Object{
 		&corev1.Service{
 			Spec: corev1.ServiceSpec{

--- a/pkg/kubernetes/deployments.go
+++ b/pkg/kubernetes/deployments.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 
-	"github.com/leanix/leanix-k8s-connector/pkg/logger"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -13,9 +12,6 @@ func (k *API) Deployments(namespace string) (*v1.DeploymentList, error) {
 	deployments, err := k.Client.AppsV1().Deployments(namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
-	}
-	for _, deployment := range deployments.Items {
-		logger.Infof("Deployment: name=%s, namespace=%s, labels=%v", deployment.Name, deployment.Namespace, deployment.Labels)
 	}
 	return deployments, nil
 }

--- a/pkg/kubernetes/deployments_test.go
+++ b/pkg/kubernetes/deployments_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/leanix/leanix-k8s-connector/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +12,6 @@ import (
 )
 
 func TestDeployments(t *testing.T) {
-	logger.Init()
 	// create a dummy nodes
 	dummyDeployments := []runtime.Object{
 		&appsv1.Deployment{


### PR DESCRIPTION
Add namespace name to id to create actual unique items. 
Otherwise any deployment from the same cluster with the same name will have the same ID