### PR TITLE
HEL-3037 Exclude blacklisted namespaces by using FieldSelectors

### DIFF
--- a/pkg/kubernetes/api.go
+++ b/pkg/kubernetes/api.go
@@ -26,10 +26,10 @@ func NewAPI(config *rest.Config) (*API, error) {
 
 type GetKubernetesAPI func(config *rest.Config) (*API, error)
 
-// BlacklistFieldSelector builds a Field Selector string to filter the reponse to not
-// include resources, that live in the blacklisted namespaces.
-func BlacklistFieldSelector(blacklistedNamespaces []string) string {
-	namespaceSelectors := Prefix(blacklistedNamespaces, "metadata.namespace!=")
+// NamespaceBlacklistFieldSelector builds a Field Selector string to filter the response to not
+// include namespaces that belong to the blacklisted namespaces
+func NamespaceBlacklistFieldSelector(blacklistedNamespaces []string) string {
+	namespaceSelectors := Prefix(blacklistedNamespaces, "metadata.name!=")
 	return strings.Join(namespaceSelectors, ",")
 }
 

--- a/pkg/kubernetes/api_test.go
+++ b/pkg/kubernetes/api_test.go
@@ -9,9 +9,9 @@ import (
 func TestBlacklistFieldSelector(t *testing.T) {
 	blacklist := []string{"kube-system", "private"}
 
-	fieldSelector := BlacklistFieldSelector(blacklist)
+	fieldSelector := NamespaceBlacklistFieldSelector(blacklist)
 
-	assert.Equal(t, "metadata.namespace!=kube-system,metadata.namespace!=private", fieldSelector)
+	assert.Equal(t, "metadata.name!=kube-system,metadata.name!=private", fieldSelector)
 }
 
 func TestPrefix(t *testing.T) {

--- a/pkg/kubernetes/namespaces.go
+++ b/pkg/kubernetes/namespaces.go
@@ -2,42 +2,15 @@ package kubernetes
 
 import (
 	"context"
-	"regexp"
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var replacer = strings.NewReplacer(
-	"*", "\\\\*",
-)
-
 // Namespaces gets the list of blacklisted namespaces
 func (k *API) Namespaces(blacklistedNamespaces []string) (*v1.NamespaceList, error) {
-	namespaces, err := k.Client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	namespaces, err := k.Client.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{FieldSelector: NamespaceBlacklistFieldSelector(blacklistedNamespaces)})
 	if err != nil {
 		return nil, err
 	}
 	return namespaces, err
-}
-
-// Namespaces gets the list of blacklisted namespaces
-func (k *API) BlackListNamespaces(blacklistedNamespaces []string) (map[string]interface{}, error) {
-	namespaces, err := k.Namespaces(blacklistedNamespaces)
-	if err != nil {
-		return nil, err
-	}
-	blacklist := make(map[string]interface{}, 0)
-	for _, m := range blacklistedNamespaces {
-		for _, n := range namespaces.Items {
-			t := replacer.Replace(strings.Trim(m, ","))
-			re := regexp.MustCompile(t)
-			if re.MatchString(n.Name) {
-				blacklist[n.Name] = struct{}{}
-			}
-		}
-	}
-
-	return blacklist, nil
 }


### PR DESCRIPTION
I changed the existing FieldSelector which we never used and made it fitting for the namespace api.
So now we don't fetch all namespaces and then filter afterwards but instead we filter directly in the kubernetes API.